### PR TITLE
Remove call to $I_T$ in description

### DIFF
--- a/problems/problem8/description.tex
+++ b/problems/problem8/description.tex
@@ -209,7 +209,7 @@ The log of the detection amplitude has a Gaussian distribution with a mean
 determined by the event magnitude and travel time.
 
 \[\log(\Lambda_a^{ik}) \sim \text{Gaussian}(\ \cdot \ | \ \mu^k_{a0} 
-+ \mu^k_{a1} e^i_m + \mu^k_{a2} I_T(\Delta_{ik})\  ,\ \sigma_a^k \ ) . \]
++ \mu^k_{a1} e^i_m + \mu^k_{a2} \Delta_{ik}\  ,\ \sigma_a^k \ ) . \]
 
 
 \subsection{False Detections}


### PR DESCRIPTION
The provided Python code suggests that this is a typo.
